### PR TITLE
Support 'suse' platform with upgrade_packages recipe

### DIFF
--- a/recipes/upgrade_packages.rb
+++ b/recipes/upgrade_packages.rb
@@ -24,12 +24,13 @@ upgrade_cmd = value_for_platform(
   ["centos","redhat","scientific","fedora","amazon"] => {
     "default" => "yum -y update && yum -y upgrade"
   },
+  "suse" => { "default" => "zypper --non-interactive update" },
   "arch" => { "default" => "pacman --sync --refresh --sysupgrade --noprogressbar -q" },
   "freebsd" => { "default" => "portupgrade -af" },
   "mac_os_x" => { "default" => "port sync" }
 )
 
-e = execute "upgrade packages" do
+e = execute "upgrade system packages" do
   command upgrade_cmd
   action :nothing
 end


### PR DESCRIPTION
Have platform suse use zypper update in non-interactive mode.

Also piggyback minor enhancement, rename execute resource to 'upgrade system packages'.
