### PR TITLE
/etc/timezone file was not updated on ubuntu.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,3 +36,7 @@ This file is used to list changes made in each version of the system cookbook.
 0.3.3
 -----
 - Revision only to address https://github.com/xhost-cookbooks/system/issues/6
+
+0.3.4
+-----
+- Revision only to address https://github.com/xhost-cookbooks/system/issues/8

--- a/metadata.rb
+++ b/metadata.rb
@@ -6,7 +6,7 @@ maintainer_email 'cookbooks@xhost.com.au'
 license          'Apache 2.0'
 description      'Installs/Configures system elements such as the hostname and timezone.'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '0.3.3'
+version          '0.3.4'
 
 recipe           'system::default',             "Sets the system's hostname and timezone, updates the system's installed packages."
 recipe           'system::timezone',            "Sets the system's' timezone."

--- a/providers/timezone.rb
+++ b/providers/timezone.rb
@@ -23,7 +23,7 @@ action :set do
 
   log("tz-info (before): #{Time.now.strftime('%z %Z')}")
 
-  if %w(debian ubuntu').member? node['platform']
+  if %w(debian ubuntu).member? node['platform']
     package 'tzdata'
 
     bash 'dpkg-reconfigure tzdata' do


### PR DESCRIPTION
Simple modification - removed extra quote in ubuntu. 
