### PR TITLE
Make timezone recipe/lwrp less noisy

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -16,7 +16,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-default['system']['timezone'] = 'UTC'
+default['system']['timezone'] = 'Etc/UTC'
 default['system']['short_hostname'] = node['hostname']
 default['system']['domain_name'] = 'localdomain'
 default['system']['static_hosts'] = {}

--- a/providers/hostname.rb
+++ b/providers/hostname.rb
@@ -185,7 +185,7 @@ action :set do
   # this can be the the case with ec2 ebs start
   execute "ensure hostname sync'd" do
     command "hostname #{fqdn}"
-    not_if { fqdn ==  Mixlib::ShellOut.new('hostname -f').run_command.stdout }
+    not_if { fqdn == Mixlib::ShellOut.new('hostname -f').run_command.stdout }
   end
 
   # rightscale support: rightlink CLI tools, rs_tag

--- a/providers/timezone.rb
+++ b/providers/timezone.rb
@@ -32,17 +32,16 @@ action :set do
       action :nothing
     end
 
-    template '/etc/timezone' do
-      source 'timezone.conf.erb'
+    file '/etc/timezone' do
       owner 'root'
       group 'root'
-      mode 0644
+      content "#{new_resource.timezone}\n"
       notifies :run, 'bash[dpkg-reconfigure tzdata]'
     end
   end
 
   link '/etc/localtime' do
-    to "/usr/share/zoneinfo/#{new_resource.name}"
+    to "/usr/share/zoneinfo/#{new_resource.timezone}"
     notifies :restart, "service[#{node['system']['cron_service_name']}]", :immediately
   end
 

--- a/resources/timezone.rb
+++ b/resources/timezone.rb
@@ -18,7 +18,8 @@
 
 attribute :timezone,
           kind_of: String,
-          default: 'UTC'
+          default: 'Etc/UTC',
+          name_attribute: true
 
 actions :set
 

--- a/templates/default/timezone.conf.erb
+++ b/templates/default/timezone.conf.erb
@@ -1,1 +1,0 @@
-<%= node['system']['timezone'] %>


### PR DESCRIPTION
I've noticed race condition between chef-client and reconfigure tzdata, every chef run `/etc/localtime` was recreated and cron restarted. If you accept this I can update metadata.rb.

```bash
  * template[/etc/timezone] action create
    - update content in file /etc/timezone from f0dcac to 7e5f76
    --- /etc/timezone 2015-04-15 07:30:54.263510327 +0000
    +++ /tmp/chef-rendered-template20150415-16772-1xzmonp 2015-04-15 07:37:50.915510327 +0000
    @@ -1,2 +1,2 @@
    -Etc/UTC
    +UTC
  * link[/etc/localtime] action create
    - unlink existing symlink to file at /etc/localtime
    - create symlink at /etc/localtime to /usr/share/zoneinfo/UTC
  * service[cron] action restart
    - restart service service[cron]
  * ruby_block[verify linked timezone] action run
    - execute the ruby block verify linked timezone
```

- while plain 'UTC' is used as default, reconfigure tzdata is executed and file content is replaced with 'Etc/UTC' + newline, thus chef is recreating file during next run with 'UTC' again
- timezone attribute was never used
- /etc/localtime template was replaced with file, it's just one line
- new line was added to end of /etc/localtime