### PR TITLE
New attribute to optionally not include cron

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ See `attributes/default.rb` for default values.
 - `node['system']['workgroup']` - the NetBIOS workgroup name to set on the node, default is `WORKGROUP` (OS X only)
 - `node['system']['static_hosts']` - a hash of static hosts to add to /etc/hosts
 - `node['system']['upgrade_packages']` - whether to upgrade the system's packages, default `true`
+- `node['system']['enable_cron']` - whether to include the cron recipe, default `true`
 - `node['system']['packages']['install']` - an array of packages to install (also supports remote package URLs)
 - `node['system']['packages']['install_compile_time']` - an array of packages to install in Chef's compilation phase (also supports remote package URLs)
 - `node['system']['permanent_ip']` - whether the system has a permenent IP address (http://www.debian.org/doc/manuals/debian-reference/ch05.en.html#_the_hostname_resolution)

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -32,6 +32,7 @@ default['system']['workgroup'] = 'WORKGROUP'
 default['system']['static_hosts'] = {}
 default['system']['upgrade_packages'] = true
 default['system']['permanent_ip'] = true
+default['system']['enable_cron'] = true
 default['system']['packages']['install'] = []
 default['system']['packages']['install_compile_time'] = []
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -136,7 +136,7 @@ attribute 'system/upgrade_packages',
 
 attribute 'system/enable_cron',
           display_name: 'Enable cron recipe',
-          description: "Whether or not the system::timezone recipe will include the cron recipe.",
+          description: 'Whether or not the system::timezone recipe will include the cron recipe.',
           required: 'optional',
           choice: %w(true false),
           default: true,

--- a/metadata.rb
+++ b/metadata.rb
@@ -6,7 +6,7 @@ maintainer_email 'cookbooks@xhost.com.au'
 license          'Apache 2.0'
 description      'Installs/Configures system elements such as the hostname and timezone.'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '0.7.0'
+version          '0.7.1'
 
 recipe           'system::default',             "Sets the system's hostname and timezone, updates the system's installed packages."
 recipe           'system::timezone',            "Sets the system's' timezone."
@@ -133,6 +133,14 @@ attribute 'system/upgrade_packages',
           required: 'optional',
           choice: %w(true false),
           recipes: ['system::upgrade_packages']
+
+attribute 'system/enable_cron',
+          display_name: 'Enable cron recipe',
+          description: "Whether or not the system::timezone recipe will include the cron recipe.",
+          required: 'optional',
+          choice: %w(true false),
+          default: true,
+          recipes: ['system::timezone']
 
 attribute 'system/packages/install',
           display_name: 'Install Packages',

--- a/metadata.rb
+++ b/metadata.rb
@@ -6,7 +6,7 @@ maintainer_email 'cookbooks@xhost.com.au'
 license          'Apache 2.0'
 description      'Installs/Configures system elements such as the hostname and timezone.'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '0.7.1'
+version          '0.7.0'
 
 recipe           'system::default',             "Sets the system's hostname and timezone, updates the system's installed packages."
 recipe           'system::timezone',            "Sets the system's' timezone."

--- a/providers/timezone.rb
+++ b/providers/timezone.rb
@@ -61,7 +61,7 @@ action :set do
 
   # this can be removed once arch linux support is in the cron cookbook
   # https://github.com/opscode-cookbooks/cron/pull/49 needs merge
-  if platform?('arch')
+  if platform?('arch') && node['system']['enable_cron']
     package 'cronie'
 
     service 'cron' do

--- a/resources/timezone.rb
+++ b/resources/timezone.rb
@@ -30,7 +30,5 @@ def initialize(*args)
 
   # arch can be removed once arch linux support is in the cron cookbook
   # https://github.com/opscode-cookbooks/cron/pull/49 needs merge
-  if node['system']['enable_cron'] && !(node['platform'] == 'arch' || node['platform'] == 'mac_os_x' || node['platform'] == 'freebsd')
-    @run_context.include_recipe 'cron'
-  end
+  @run_context.include_recipe 'cron' if node['system']['enable_cron'] && !(node['platform'] == 'arch' || node['platform'] == 'mac_os_x' || node['platform'] == 'freebsd')
 end

--- a/resources/timezone.rb
+++ b/resources/timezone.rb
@@ -30,5 +30,7 @@ def initialize(*args)
 
   # arch can be removed once arch linux support is in the cron cookbook
   # https://github.com/opscode-cookbooks/cron/pull/49 needs merge
-  @run_context.include_recipe 'cron' unless node['platform'] == 'arch' || node['platform'] == 'mac_os_x' || node['platform'] == 'freebsd'
+  if node['system']['enable_cron'] && !(node['platform'] == 'arch' || node['platform'] == 'mac_os_x' || node['platform'] == 'freebsd')
+    @run_context.include_recipe 'cron'
+  end
 end


### PR DESCRIPTION
Set `node['system']['enable_cron']` to false to not include the cron recipe. This
is useful for me, since I have Arch systems that don't have cron at all (relying
on systemd timers instead). Including cron causes the chef run to fail.