### PR TITLE
make it possible to control which phase package upgrades occur

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ See `attributes/default.rb` for default values.
 - `node['system']['workgroup']` - the NetBIOS workgroup name to set on the node, default is `WORKGROUP` (OS X only)
 - `node['system']['static_hosts']` - a hash of static hosts to add to `/etc/hosts`
 - `node['system']['upgrade_packages']` - whether to upgrade the system's packages, default `true`
+- `node['system']['upgrade_packages_at_compile']` - whether upgrade of the system's packages in Chef's compilation phase, default `true`
 - `node['system']['enable_cron']` - whether to include the cron recipe, default `true`
 - `node['system']['packages']['install']` - an array of packages to install (also supports remote package URLs)
 - `node['system']['packages']['install_compile_time']` - an array of packages to install in Chef's compilation phase (also supports remote package URLs)

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -32,6 +32,7 @@ default['system']['workgroup'] = 'WORKGROUP'
 default['system']['static_hosts'] = {}
 default['system']['manage_hostsfile'] = true
 default['system']['upgrade_packages'] = true
+default['system']['upgrade_packages_at_compile'] = true
 default['system']['permanent_ip'] = true
 default['system']['primary_interface'] = node['network']['default_interface']
 default['system']['enable_cron'] = true

--- a/metadata.rb
+++ b/metadata.rb
@@ -129,7 +129,16 @@ attribute 'system/workgroup',
 
 attribute 'system/upgrade_packages',
           display_name: 'Upgrade Packages',
-          description: "Whether or not the system::upgrade_packages recipe will physically update the system's installed packages (in compile time).",
+          description: "Whether or not the system::upgrade_packages recipe will physically update the system's installed packages.",
+          required: 'optional',
+          type: 'boolean',
+          choice: [true, false],
+          default: true,
+          recipes: ['system::upgrade_packages']
+
+attribute 'system/upgrade_packages_at_compile',
+          display_name: 'Upgrade Packages at compile time',
+          description: "Whether or not the system::upgrade_packages recipe will update the system's installed packages at compile time.",
           required: 'optional',
           type: 'boolean',
           choice: [true, false],

--- a/recipes/upgrade_packages.rb
+++ b/recipes/upgrade_packages.rb
@@ -36,10 +36,11 @@ upgrade_cmd = value_for_platform(
 
 e = execute 'upgrade system packages' do
   command upgrade_cmd
-  action :nothing
+  action(node['system']['upgrade_packages_at_compile'] ? :nothing : :run)
+  only_if { node['system']['upgrade_packages'] }
 end
 
-if node['system']['upgrade_packages']
+if node['system']['upgrade_packages_at_compile']
   # supports type string if defined through metadata
-  e.run_action(:run) unless node['system']['upgrade_packages'] == 'false'
+  e.run_action(:run)
 end


### PR DESCRIPTION
Hello, a feature for your consideration.

This one adds a new attribute to additionally control package upgrades. In the current cookbook, this happens at compile time only. This is not always the most desirable thing to happen. (Mostly finding difficulties when trying to run cookbooks that update kernel modules via dkms, which really like the currently running kernel to also be the most recent currently installed)

This leaves the current behaviour as the default, but provides the option of moving upgrade to occur when the include happens, which gives greater control over behaviour when making wrapper cookbooks.

I have not included a test case yet, partly due to the difficulties in testing the nature of this, and partly because the package upgrade path is not a part of the current suite of tests.

Let me know if you'd like to see anything revised in the pull request and I'll make it so.