### PR TITLE
Feature network restart control

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -61,7 +61,7 @@ platforms:
         primary_interface: em1
     driver_config:
         ssh:
-          shell: '/bin/sh'
+          shell: "'/bin/sh'"
         network:
           - ["private_network", {ip: "172.16.172.16"}]
   - name: freebsd-9.3
@@ -70,7 +70,7 @@ platforms:
         primary_interface: em1
     driver_config:
         ssh:
-          shell: '/bin/sh'
+          shell: "'/bin/sh'"
         network:
           - ["private_network", {ip: "172.16.172.16"}]
 suites:

--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ See `attributes/default.rb` for default values.
 - `node['system']['manage_hostsfile']` - whether or not to manage `/etc/hostsfile` (in any way)
 - `node['system']['permanent_ip']` - whether the system has a permenent IP address (http://www.debian.org/doc/manuals/debian-reference/ch05.en.html#_the_hostname_resolution)
 - `node['system']['primary_interface']` - Specify primary network interface, used by hostname to set the correct address in hostsfile, default is `node['network']['default_interface']`
+- `node['system']['delay_network_restart']` - whether to trigger restart event as delayed. false causes an immediate restart instead. default `true`
 
 Attributes (all arrays) to manipulate the system-wide profile (usually for `/etc/profile`):
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -35,6 +35,7 @@ default['system']['upgrade_packages'] = true
 default['system']['upgrade_packages_at_compile'] = true
 default['system']['permanent_ip'] = true
 default['system']['primary_interface'] = node['network']['default_interface']
+default['system']['delay_network_restart'] = true
 default['system']['enable_cron'] = true
 default['system']['packages']['install'] = []
 default['system']['packages']['install_compile_time'] = []

--- a/metadata.rb
+++ b/metadata.rb
@@ -200,6 +200,15 @@ attribute 'system/primary_interface',
           required: 'optional',
           recipes: ['system::hostname', 'system::default']
 
+attribute 'system/delay_network_restart',
+          display_name: 'Delay Network Restart',
+          description: "Whether or not the system hostnamem provider will trigger a network restart as delayed vs. immediate.",
+          required: 'optional',
+          type: 'boolean',
+          choice: [true, false],
+          default: true,
+          recipes: ['system::hostname', 'system::default']
+
 attribute 'system/profile/path',
           display_name: 'System Profile Path',
           description: 'Overrides the default path for the system.',

--- a/metadata.rb
+++ b/metadata.rb
@@ -202,7 +202,7 @@ attribute 'system/primary_interface',
 
 attribute 'system/delay_network_restart',
           display_name: 'Delay Network Restart',
-          description: "Whether or not the system hostnamem provider will trigger a network restart as delayed vs. immediate.",
+          description: 'Whether or not the system hostnamem provider will trigger a network restart as delayed vs. immediate.',
           required: 'optional',
           type: 'boolean',
           choice: [true, false],

--- a/providers/hostname.rb
+++ b/providers/hostname.rb
@@ -247,7 +247,7 @@ action :set do
     only_if { platform_family?('rhel') }
     only_if { node['platform_version'] < '7.0' }
     not_if { ::File.readlines('/etc/sysconfig/network').grep(/HOSTNAME=#{fqdn}/).any? }
-    notifies :restart, 'service[network]', :delayed
+    notifies :restart, 'service[network]', node['system']['delay_network_restart'] ? :delayed : :immediately
   end
 
   ruby_block 'show hostnamectl' do


### PR DESCRIPTION
provides a new attrib to control if network restart initiated by the hostname provider happens in a delayed or immediate manner. the default preserves the existing delayed behaviour while allowing the option to instead ask for an immediate restart should that suit your needs.

a second commit fixes an issue seen while running the test suite where the freebsd platforms was not generating valid Vagrantfiles due to a lack of quoting on shell definitions, causing the vagrant files generated to interpret the string for the shell as a regex instead.
