### PR TITLE
system_profile does not use included templates.

### DIFF
--- a/providers/profile.rb
+++ b/providers/profile.rb
@@ -27,7 +27,9 @@ action :configure do
             new_resource.path_append,
       append_scripts: new_resource.append_scripts
     }
-
+    # Specify that the templates are from the system
+    # cookbook
+    cookbook 'system'
     if new_resource.template
       new_resource.template.each do |attr, value|
         send attr, value


### PR DESCRIPTION
Currently if you add the following code to a cookbook which has the system cookbook as a dependency

    system_profile '/etc/profile' do
      path ['/usr/local/prgm/bin']
    end

Then you receive the following error:

    ERROR: template[/etc/profile] (/tmp/vagrant-chef/42964f892d0bdc1f3523934e6c16f380/cookbooks/system/providers/profile.rb line 21) had an error:    
    Chef::Exceptions::FileNotFound: Cookbook 'prgm-chef' (0.1.0) does not contain a file at any of these locations:
    ==> default:   templates/centos-6.7/profile.erb
    ==> default:   templates/centos/profile.erb
    ==> default:   templates/default/profile.erb
    ==> default:   templates/profile.erb

This pull request fixes this by explicitly specifying that the template is located in the system cookbook.

Additional information about the issue can be found here https://github.com/chef/chef/issues/3681