### PR TITLE
Adding raspbian platform support

### DIFF
--- a/attributes/profile.rb
+++ b/attributes/profile.rb
@@ -25,7 +25,7 @@ when 'arch'
                                           '/usr/bin']
   # /usr/share/base-files/profile postinst installs to
   # /etc/profile from the `base-files` package
-when 'debian'
+when 'debian', 'raspbian'
   default['system']['profile']['path'] = ['/usr/local/bin',
                                           '/usr/bin',
                                           '/bin',

--- a/providers/hostname.rb
+++ b/providers/hostname.rb
@@ -308,7 +308,7 @@ action :set do
     # /etc/init.d/hostname.sh on debian does not ignore them
     content "#{short_hostname}\n"
     action :create
-    notifies :start, resources("service[#{service_name}]"), :immediately if platform?('debian') or platform?('raspbian')
+    notifies :start, resources("service[#{service_name}]"), :immediately if platform?('debian', 'raspbian')
     notifies :restart, resources("service[#{service_name}]"), :immediately if platform?('ubuntu')
     notifies :create, 'ruby_block[update network sysconfig]', :immediately
     notifies :run, 'execute[run domainname]', :immediately

--- a/providers/hostname.rb
+++ b/providers/hostname.rb
@@ -199,7 +199,7 @@ action :set do
   # (re)start the hostname[.sh] service on debian-based distros
   if platform_family?('debian')
     case node['platform']
-    when 'debian'
+    when 'debian', 'raspbian'
       service_name = 'hostname.sh'
       service_supports = {
         start: true,
@@ -308,7 +308,7 @@ action :set do
     # /etc/init.d/hostname.sh on debian does not ignore them
     content "#{short_hostname}\n"
     action :create
-    notifies :start, resources("service[#{service_name}]"), :immediately if platform?('debian')
+    notifies :start, resources("service[#{service_name}]"), :immediately if platform?('debian') or platform?('raspbian')
     notifies :restart, resources("service[#{service_name}]"), :immediately if platform?('ubuntu')
     notifies :create, 'ruby_block[update network sysconfig]', :immediately
     notifies :run, 'execute[run domainname]', :immediately


### PR DESCRIPTION
Ohai sets `node['platform']` to `raspbian` so some recipes of this cookbook were unusable. This PR wants to fix this